### PR TITLE
add a hot-keyed timeline to undo redo, ensure undo/redo is really going history item by history item

### DIFF
--- a/app/channels/chat_channel.rb
+++ b/app/channels/chat_channel.rb
@@ -99,8 +99,12 @@ class ChatChannel < ApplicationCable::Channel
     
     # Clean up the connection
     if @external_ws_connection
-      @external_ws_connection.close
-      Rails.logger.info "Closed external WebSocket connection for: #{connection_id}"
+      begin
+        @external_ws_connection.close
+        Rails.logger.info "Closed external WebSocket connection for: #{connection_id}"
+      rescue RuntimeError => e
+        Rails.logger.warn "Could not close WebSocket connection: #{e.message}"
+      end
     end
   end
 

--- a/app/controllers/page_histories_controller.rb
+++ b/app/controllers/page_histories_controller.rb
@@ -62,6 +62,17 @@ class PageHistoriesController < ApplicationController
     end
   end
 
+  def list
+    @page = Page.find(params[:id])
+    @histories = @page.page_histories.order(created_at: :desc)
+    
+    render json: @histories.map { |history| 
+      history.as_json.merge(
+        is_current_version: (history.id == @page.current_version_id)
+      )
+    }
+  end
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_page_history

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -211,6 +211,21 @@ class PagesController < ApplicationController
     end
   end
 
+  def restore_with_history
+    @page = Page.friendly.find(params[:id])
+    @page_history = PageHistory.find(params[:page_history_id])
+    
+    if @page.restore_with_history(@page_history, "Restored by user")
+      respond_to do |format|
+        format.json { render json: { success: true, message: 'Page restored successfully' } }
+      end
+    else
+      respond_to do |format|
+        format.json { render json: { success: false, error: 'Failed to restore page' }, status: :unprocessable_entity }
+      end
+    end
+  end
+
   def sitemap_xml
     @pages = current_site.pages
     

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -129,12 +129,18 @@ class PagesController < ApplicationController
   # PATCH/PUT /pages/1 or /pages/1.json
   def update
     message = params[:message].present? ? params[:message] : "User Edit"
-    @page.save_history(message)
+    Rails.logger.info "Attempting to update page #{@page.id} with message: #{message}"
+    
     respond_to do |format|
       if @page.update(page_params)
+        Rails.logger.info "Successfully updated page #{@page.id}"
+        @page.save_history(message)
+        Rails.logger.info "Saved page history with message: #{message}"
+        
         format.html { redirect_to page_url(@page.id), notice: "web page was successfully updated." }
         format.json { render :show, status: :ok, location: @page }
       else
+        Rails.logger.error "Failed to update page #{@page.id}. Errors: #{@page.errors.full_messages}"
         format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @page.errors, status: :unprocessable_entity }
       end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -5,6 +5,7 @@ class Page < ApplicationRecord
 
   belongs_to :site
   belongs_to :organization
+  belongs_to :current_version, class_name: 'PageHistory', optional: true, foreign_key: 'current_version_id'
   
   has_many :page_histories, dependent: :destroy
   has_many :posts, dependent: :nullify
@@ -194,16 +195,26 @@ class Page < ApplicationRecord
     end
   end
 
-  def undo
-    return false unless current_version_id
+  def next_version
+    return nil unless current_version
+    page_histories.where('created_at > ?', current_version.created_at)
+                  .order(created_at: :asc)
+                  .first
+  end
 
-    current_history = page_histories.find(current_version_id)
-    previous_history = page_histories.where('created_at < ?', current_history.created_at)
-                                   .order(created_at: :desc)
-                                   .first
+  def previous_version
+    return nil unless current_version
+    page_histories.where('created_at < ?', current_version.created_at)
+                  .order(created_at: :desc)
+                  .first
+  end
+
+  def undo
+    return false unless current_version
+    previous = previous_version
     
-    if previous_history
-      restore_with_history(previous_history, "Undo to previous version")
+    if previous
+      restore_with_history(previous, "Undo to previous version")
       true
     else
       false
@@ -211,22 +222,41 @@ class Page < ApplicationRecord
   end
 
   def redo
-    return false unless current_version_id
-
-    current_history = page_histories.find(current_version_id)
-    next_history = page_histories.where('created_at > ?', current_history.created_at)
-                                .order(created_at: :asc)
-                                .first
+    return false unless current_version
+    next_ver = next_version
     
-    if next_history
-      restore_with_history(next_history, "Redo to next version")
+    if next_ver
+      restore_with_history(next_ver, "Redo to next version")
       true
     else
       false
     end
   end
 
-  private
+  def current_version
+    return nil unless current_version_id
+    page_histories.find_by(id: current_version_id)
+  end
+
+  def version_number
+    return 0 unless current_version_id
+    page_histories.where('created_at <= ?', current_version.created_at).count
+  end
+
+  def total_versions
+    page_histories.count
+  end
+
+  def latest_version?
+    return true unless current_version_id
+    !page_histories.where('created_at > ?', current_version.created_at).exists?
+  end
+
+  def first_version?
+    return true unless current_version_id
+    !page_histories.where('created_at < ?', current_version.created_at).exists?
+  end
+
 
   def restore_with_history(page_history, message)
     self.content = page_history.content
@@ -237,6 +267,8 @@ class Page < ApplicationRecord
       current_version_id: page_history.id
     )
   end
+
+  private
 
   # Create a new web site for the organization
   def create_new_site

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -169,21 +169,38 @@ class Page < ApplicationRecord
   end
 
   def save_history(user_message = nil)
+    puts "\n=== Starting save_history ==="
+    puts "Initial user_message: #{user_message.inspect}"
+    
     return unless persisted?  # Make sure the page is saved first
+    puts "Page is persisted, continuing..."
     
     user_message ||= "Save version"
+    puts "Final user_message: #{user_message}"
     
     # Check if there's a previous history entry with the same content
     current_history = page_histories.find_by(id: current_version_id)
-    return current_history if current_history&.content == self.content
+    puts "Current history found: #{current_history.inspect}"
     
-    # If we're saving from a previous version, prune future versions
-    if current_history
-      page_histories.where('created_at > ?', current_history.created_at).destroy_all
+    same = current_history&.content == self.content
+    puts "Content is same as current history? #{same}"
+
+    if same
+      puts "=== Returning existing history (no changes) ==="
+      return current_history
     end
     
+    # If we're saving from a previous version, prune future versions
+    # if current_history
+    #   page_histories.where('created_at > ?', current_history.created_at).destroy_all
+    # end
+
     # Create new history entry if content is different
+    puts "Creating new history entry..."
     history = self.page_histories.create(content: self.content, user_message: user_message)
+    puts "New history created: #{history.inspect}"
+    
+    puts "Updating current_version_id to: #{history.id}"
     self.update_column(:current_version_id, history.id)
     history
   end

--- a/app/models/page_history.rb
+++ b/app/models/page_history.rb
@@ -1,3 +1,7 @@
 class PageHistory < ApplicationRecord
   belongs_to :page
+
+  def is_current_version?
+    page&.current_version_id == id
+  end
 end

--- a/app/views/shared/llama_bot/_side_panel.html.erb
+++ b/app/views/shared/llama_bot/_side_panel.html.erb
@@ -690,3 +690,5 @@
   #llama-menu-items button:nth-child(2) { transition-delay: 0.2s; }
   #llama-menu-items button:nth-child(3) { transition-delay: 0.3s; }
 </style>
+
+<%= render partial: 'shared/llama_bot/timeline_overlay' %>

--- a/app/views/shared/llama_bot/_timeline_overlay.html.erb
+++ b/app/views/shared/llama_bot/_timeline_overlay.html.erb
@@ -1,0 +1,159 @@
+<!-- Timeline Overlay -->
+<div id="timelineOverlay" class="fixed right-0 top-0 h-full w-96 bg-white shadow-lg transform translate-x-full transition-transform duration-300 overflow-y-auto z-50" data-llama="exclude_when_saving_contenteditable_edits">
+  <div class="p-4 border-b border-gray-200">
+    <div class="flex justify-between items-center">
+      <h2 class="text-xl font-semibold">Page History</h2>
+      <button onclick="toggleTimelineOverlay()" class="text-gray-500 hover:text-gray-700">
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+        </svg>
+      </button>
+    </div>
+  </div>
+
+  <div class="relative px-4">
+    <!-- Timeline line -->
+    <div class="absolute left-9 top-0 bottom-0 w-0.5 bg-gray-200"></div>
+
+    <!-- Timeline entries container -->
+    <div id="timelineEntries" class="relative py-4">
+      <!-- Loading spinner will be replaced with entries -->
+      <div class="flex justify-center">
+        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+function toggleTimelineOverlay() {
+  const overlay = document.getElementById('timelineOverlay');
+  overlay.classList.toggle('translate-x-full');
+  
+  if (!overlay.classList.contains('translate-x-full')) {
+    loadTimelineHistory();
+    document.addEventListener('keydown', handleEscKey);
+  } else {
+    document.removeEventListener('keydown', handleEscKey);
+  }
+}
+
+function handleEscKey(event) {
+  if (event.key === 'Escape') {
+    const overlay = document.getElementById('timelineOverlay');
+    overlay.classList.add('translate-x-full');
+    document.removeEventListener('keydown', handleEscKey);
+  }
+}
+
+function createTimelineEntry(history) {
+  const entry = document.createElement('div');
+  entry.className = 'flex gap-4 mb-6 relative';
+  
+  const timestamp = new Date(history.created_at).toLocaleString();
+  let contentLength = history.content.length;
+  const isCurrentVersion = history.is_current_version;
+
+  entry.innerHTML = `
+    <div class="relative z-10">
+      <div class="w-6 h-6 rounded-full ${isCurrentVersion ? 'bg-green-500' : 'bg-blue-500'} flex items-center justify-center">
+        <svg class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
+                d="${isCurrentVersion ? 'M5 13l4 4L19 7' : 'M12 12h0.01'}" />
+        </svg>
+      </div>
+    </div>
+    <div class="flex-1">
+      <div class="bg-white rounded-lg border p-4 ${isCurrentVersion ? 'ring-2 ring-green-500' : ''}">
+        <div class="space-y-2">
+          <div class="flex justify-between items-start">
+            <div>
+              <p class="text-gray-700">
+                ${isCurrentVersion ? '<span class="font-semibold text-green-600">Current Version</span> - ' : ''}
+                ${timestamp}
+              </p>
+              <p class="text-sm text-gray-500">Content size: ${contentLength} bytes</p>
+            </div>
+            ${!isCurrentVersion ? `
+              <button onclick="restoreVersion('${history.id}')" 
+                      class="px-4 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors">
+                Restore
+              </button>
+            ` : ''}
+          </div>
+          ${history.user_message ? `
+            <div class="pt-2">
+              <p class="text-sm text-gray-700">Edit: ${history.user_message}</p>
+            </div>
+          ` : ''}
+        </div>
+      </div>
+    </div>
+  `;
+
+  return entry;
+}
+
+function loadTimelineHistory() {
+  console.log("Loading History...")
+  const container = document.getElementById('timelineEntries');
+  const pageId = '<%= @page&.id %>';
+  
+  fetch(`/page_histories/${pageId}/list.json`)
+    .then(response => {
+      console.log('Raw response:', response);
+      return response.json();
+    })
+    .then(data => {
+      console.log('Parsed JSON data:', data);
+      container.innerHTML = '';
+      data.forEach(item => {
+        container.appendChild(createTimelineEntry(item));
+      });
+    })
+    .catch(error => {
+      console.error('Error loading timeline history:', error);
+      container.innerHTML = '<p class="text-red-500 text-center">Error loading history</p>';
+    });
+}
+
+function restoreVersion(historyId) {
+  const pageId = '<%= @page&.id %>';
+  
+  fetch(`/pages/${pageId}/restore_with_history`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': document.querySelector('[name="csrf-token"]').content
+    },
+    body: JSON.stringify({ page_history_id: historyId })
+  })
+  .then(response => response.json())
+  .then(data => {
+    if (data.success) {
+      window.location.reload();
+    } else {
+      alert(data.error || 'Failed to restore version');
+    }
+  })
+  .catch(error => {
+    console.error('Error restoring version:', error);
+    alert('Failed to restore version');
+  });
+}
+
+// Add keyboard shortcut handler
+document.addEventListener('keydown', function(event) {
+  if (event.shiftKey && event.key.toLowerCase() === 'h') {
+    event.preventDefault();
+    toggleTimelineOverlay();
+  }
+});
+
+document.addEventListener('DOMContentLoaded', function() {
+  if (sessionStorage.getItem('showTimelineAfterReload') === 'true') {
+    sessionStorage.removeItem('showTimelineAfterReload');
+    toggleTimelineOverlay();
+  }
+});
+</script>

--- a/app/views/shared/llama_bot/_timeline_overlay.html.erb
+++ b/app/views/shared/llama_bot/_timeline_overlay.html.erb
@@ -144,7 +144,7 @@ function restoreVersion(historyId) {
 
 // Add keyboard shortcut handler
 document.addEventListener('keydown', function(event) {
-  if (event.shiftKey && event.key.toLowerCase() === 'h') {
+  if ((event.altKey) && event.key.toLowerCase() === 'h') {
     event.preventDefault();
     toggleTimelineOverlay();
   }

--- a/app/views/shared/llama_bot/javascript/_core_javascript.html.erb
+++ b/app/views/shared/llama_bot/javascript/_core_javascript.html.erb
@@ -650,6 +650,7 @@
     function undoPageChange() {
       let webPageId = "<%=@page&.id%>";
       if (webPageId) {
+        sessionStorage.setItem('showTimelineAfterReload', 'true');
         const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
         fetch(`/pages/${webPageId}/page_undo`, {
           method: 'POST',
@@ -699,6 +700,7 @@
     function redoPageChange() {
       let webPageId = "<%=@page&.id%>";
       if (webPageId) {
+        sessionStorage.setItem('showTimelineAfterReload', 'true');
         fetch(`/pages/${webPageId}/page_redo`, {
           method: 'POST',
           headers: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,10 +10,16 @@ Rails.application.routes.draw do
       post 'restore'
       post :page_undo
       post :page_redo
+      post 'restore_with_history'
     end
   end
   resources :sites
-  resources :page_histories
+  resources :page_histories do
+    member do 
+      get 'list'
+    end
+  end
+  
   devise_for :users, controllers: { registrations: 'users/registrations' }
   
   resources :users do
@@ -61,9 +67,10 @@ Rails.application.routes.draw do
   get 'sitemap.xml', to: 'pages#sitemap_xml', defaults: { format: 'xml' }
   get 'robots.txt', to: 'pages#robots_txt', defaults: { format: 'txt' }
 
-  # Catch-all route at the end
+  # Make sure this is the LAST route
   get '*path', to: 'pages#resolve_slug', constraints: lambda { |request|
-    !request.path.start_with?('/rails/') && !request.path.start_with?('/cable')
+    !request.path.start_with?('/rails/') && 
+    !request.path.start_with?('/cable') && 
+    !request.path.start_with?('/page_histories')
   }
-
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -133,7 +133,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_21_235117) do
     t.string "slug"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "wordpress_api_encoded_token"
     t.bigint "home_page_id"
     t.bigint "after_submission_page_id"
     t.index ["after_submission_page_id"], name: "index_sites_on_after_submission_page_id"
@@ -178,10 +177,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_21_235117) do
     t.datetime "last_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
-    t.datetime "mixpanel_profile_last_set_at"
-    t.string "api_token"
     t.integer "tutorial_step", default: 0
-    t.index ["api_token"], name: "index_users_on_api_token", unique: true
+    t.string "api_token"
+    t.index ["api_token"], name: "index_users_on_api_token"
     t.index ["default_site_id"], name: "index_users_on_default_site_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["organization_id"], name: "index_users_on_organization_id"


### PR DESCRIPTION
This creates a navigable undo/redo ui, with a new restore method, and a visualization of the history for the user, surfacing the stored versions in the db currently. This should be very helpful when users are trying to undo/redo many blocks at once, restoring a very old version, or other complex ops